### PR TITLE
fix(charts): Standardize error handling to prevent blank page

### DIFF
--- a/services/tradier_service.py
+++ b/services/tradier_service.py
@@ -107,7 +107,8 @@ def get_historical_data(ticker, timeframe):
     Formats the data for Chart.js.
     """
     if not TRADIER_API_KEY:
-        return {'error': 'Tradier API key not set in .env file'}
+        print("ERROR: Tradier API key not set in .env file")
+        return None
 
     # Calculate start date based on timeframe
     end_date = date.today()


### PR DESCRIPTION
This commit resolves an issue where the chart page would appear blank. The root cause was inconsistent error handling in the `get_historical_data` function.

Previously, if the Tradier API key was missing, the function would return a JSON object with an `error` key and a 200 OK status. The frontend JavaScript was not designed to handle this format and would fail with a TypeError, causing the chart to not render.

This change modifies the function to return `None` in all error cases, including the missing API key. This allows the Flask route to consistently return a proper 404 error, which the frontend correctly handles by displaying an error message to the user instead of a blank page.