### PR TITLE
fix(templates): Correct script loading in base layout

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -53,6 +53,6 @@
     </main>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/7.3.2/mdb.umd.min.js"></script>
     <script type="text/javascript" src="{{ url_for('static', filename='js/custom.js') }}"></script>
-    <script type="text/javascript" src="{{ url_for('static', filename='js/charting.js') }}"></script>
+    {% block scripts %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
This commit resolves a "Chart is not defined" error caused by an issue in the template inheritance structure.

The root cause was that the base template, `layout.html`, did not define a `{% block scripts %}`. This prevented child templates, such as `charts.html`, from injecting their page-specific scripts. As a result, the Chart.js library was never loaded on the chart page.

This fix addresses the issue by:
1.  Removing an incorrect script tag for `charting.js` from `layout.html`.
2.  Adding the necessary `{% block scripts %}` to `layout.html`, allowing child templates to correctly load their required scripts.

This ensures that Chart.js is loaded properly on the chart page, resolving the error and allowing the charts to render.