### PR TITLE
feat(charts): Display only the day number in chart labels

### DIFF
--- a/services/tradier_service.py
+++ b/services/tradier_service.py
@@ -144,8 +144,8 @@ def get_historical_data(ticker, timeframe):
 
         # Format data for Chart.js (labels array and data array)
         chart_data = {
-            'labels': [day['date'] for day in day_entries],
-            'data': [day['close'] for day in day_entries]
+            'labels': [d['date'].split('-')[-1] for d in day_entries],
+            'data': [d['close'] for d in day_entries]
         }
         return chart_data
 


### PR DESCRIPTION
This commit updates the chart's X-axis to display only the day of the month, as requested by the user.

The `get_historical_data` function in `services/tradier_service.py` has been modified to process the date strings from the API. It now extracts only the day component (e.g., '26' from '2023-10-26') for the chart labels.

This provides a cleaner, more focused view of the data on the chart, per the user's requirement.