### PR TITLE
feat(charts): Add support and resistance lines to chart

### DIFF
--- a/services/tradier_service.py
+++ b/services/tradier_service.py
@@ -142,10 +142,18 @@ def get_historical_data(ticker, timeframe):
         if not day_entries:
             return None
 
-        # Format data for Chart.js (labels array and data array)
+        # Calculate support and resistance levels from the historical data
+        low_prices = [d['low'] for d in day_entries]
+        high_prices = [d['high'] for d in day_entries]
+        support_level = min(low_prices) if low_prices else 0
+        resistance_level = max(high_prices) if high_prices else 0
+
+        # Format data for Chart.js
         chart_data = {
             'labels': [d['date'].split('-')[-1] for d in day_entries],
-            'data': [d['close'] for d in day_entries]
+            'data': [d['close'] for d in day_entries],
+            'support': support_level,
+            'resistance': resistance_level,
         }
         return chart_data
 

--- a/static/js/charting.js
+++ b/static/js/charting.js
@@ -65,20 +65,50 @@ document.addEventListener('DOMContentLoaded', () => {
                 stockChart.destroy();
             }
 
+            const datasets = [{
+                label: `${ticker} Closing Price`,
+                data: chartData.data, // Prices for the Y-axis
+                borderColor: 'rgb(75, 192, 192)',
+                backgroundColor: 'rgba(75, 192, 192, 0.1)',
+                fill: true,
+                tension: 0.1,
+                pointRadius: 1,
+            }];
+
+            // Add support line if available
+            if (chartData.support > 0) {
+                datasets.push({
+                    label: 'Support',
+                    data: Array(chartData.labels.length).fill(chartData.support),
+                    borderColor: 'rgba(40, 167, 69, 0.8)', // Green
+                    borderWidth: 2,
+                    borderDash: [5, 5],
+                    pointRadius: 0,
+                    fill: false,
+                    tension: 0,
+                });
+            }
+
+            // Add resistance line if available
+            if (chartData.resistance > 0) {
+                datasets.push({
+                    label: 'Resistance',
+                    data: Array(chartData.labels.length).fill(chartData.resistance),
+                    borderColor: 'rgba(220, 53, 69, 0.8)', // Red
+                    borderWidth: 2,
+                    borderDash: [5, 5],
+                    pointRadius: 0,
+                    fill: false,
+                    tension: 0,
+                });
+            }
+
             // Create a new chart using the data we fetched
             stockChart = new Chart(ctx, {
                 type: 'line',
                 data: {
                     labels: chartData.labels, // Dates for the X-axis
-                    datasets: [{
-                        label: `${ticker} Closing Price`,
-                        data: chartData.data, // Prices for the Y-axis
-                        borderColor: 'rgb(75, 192, 192)',
-                        backgroundColor: 'rgba(75, 192, 192, 0.1)',
-                        fill: true,
-                        tension: 0.1,
-                        pointRadius: 1,
-                    }]
+                    datasets: datasets
                 },
                 options: {
                     responsive: true,


### PR DESCRIPTION
This commit introduces a new feature to display support and resistance lines on the stock chart, enhancing its analytical value.

The implementation involves two main parts:
1.  **Backend Calculation:** The `get_historical_data` function in `services/tradier_service.py` has been updated to calculate support and resistance levels. Support is defined as the lowest low and resistance as the highest high within the selected time period. These values are added to the API response.

2.  **Frontend Rendering:** The `static/js/charting.js` script is updated to dynamically add two new datasets to the chart if the support and resistance data is available. These datasets are styled as dashed horizontal lines (green for support, red for resistance) to distinguish them from the main price line.